### PR TITLE
Mail icon

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -27,8 +27,9 @@ link = "https://www.linkedin.com/company/semla-ai"
 
 [[social]]
 name = "Email"
-icon = "fa-brands fa-envelope fa-xl"
+icon = "fa-solid fa-envelope fa-xl"
 link = "mailto:info@semla.ai"
+
 # [[social]]
 # name = "YouTube"
 # icon = "fa-brands fa-youtube fa-xl"

--- a/themes/semla/layouts/partials/head.html
+++ b/themes/semla/layouts/partials/head.html
@@ -8,5 +8,6 @@
   <link rel="stylesheet" href="{{ $style.Permalink }}" />
   <script defer src="/fontawesome/js/brands.js"></script>
   <script defer src="/fontawesome/js/solid.js"></script>
+  <script defer src="/fontawesome/js/regular.js"></script>
   <script defer src="/fontawesome/js/fontawesome.js"></script>
 </head>


### PR DESCRIPTION
It was set to use fa-brands (which is just for brands like Twitter and LinkedIn, so of course it didn't work for an envelope icon that belongs to the other group of icons), it should have been set to fa-solid or fa-regular depending on the look you were going for. I've also added the fa-regular support to head, was previously just for fa-solid (which often look better).